### PR TITLE
Fix compilation by pinning actix beta versions.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2018"
 
 [dependencies]
 libsignal-protocol = { git = "https://github.com/Michael-F-Bryan/libsignal-protocol-rs.git" }
-libsignal-service = { git = "https://github.com/Michael-F-Bryan/libsignal-service-rs.git", rev = "11d1d51" }
-libsignal-service-actix = { git = "https://github.com/Michael-F-Bryan/libsignal-service-rs.git", rev = "11d1d51" }
+libsignal-service = { git = "https://github.com/Michael-F-Bryan/libsignal-service-rs", rev = "b940d05a" }
+libsignal-service-actix = { git = "https://github.com/Michael-F-Bryan/libsignal-service-rs.git", rev = "b940d05a" }
 env_logger = "0.7"
 directories = "3.0"
 structopt = "0.3"
@@ -26,4 +26,6 @@ serde = "1.0"
 log = "0.4.8"
 sled = "*"
 prost = "*"
-actix-rt = "2.0.0-beta.1"
+actix = "=0.11.0-beta.1"
+actix-rt = "=2.0.0-beta.1"
+actix-service = "=2.0.0-beta.3"

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ use std::{path::PathBuf, time::UNIX_EPOCH};
 
 use directories::ProjectDirs;
 use futures::{channel::mpsc::channel, future, StreamExt};
-use log::{debug, info};
+use log::debug;
 use presage::{config::SledConfigStore, prelude::sync_message::Sent, Error, Manager};
 
 use structopt::StructOpt;
@@ -10,7 +10,7 @@ use structopt::StructOpt;
 use libsignal_protocol::{crypto::DefaultCrypto, Context};
 use libsignal_service::{
     configuration::SignalServers,
-    content::{sync_message, ContentBody, DataMessage, GroupContextV2, SyncMessage},
+    content::{ContentBody, DataMessage, SyncMessage},
     ServiceAddress,
 };
 


### PR DESCRIPTION
Actix beta releases are not compatible atm and fail to compile.

Also upgrade to the latest libsignal-service version.